### PR TITLE
Added 'urlbase' to config.json.template

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "My Sweet Services",
-    "port": 3000
+    "port": 3000,
+    "urlbase": ""
   },
   "services": [
     {

--- a/lib/config.js
+++ b/lib/config.js
@@ -106,7 +106,8 @@ function save(title, port, version, services) {
     'app': {
       'title'   : title,
       'port'    : port,
-      'version' : version
+      'version' : version,
+      'urlbase' : ""
     },
     'services': services
   });


### PR DESCRIPTION
Just adding a missed variable into config.json.template due to the last commit causing an error on a fresh run
```
app.use(config.app.urlbase, router);
```
This variable is being called before its being written to the config file, so a base variable with no value is the best option to fix the issue linked below.
[Unable to start - Cannot read property 'length'](https://github.com/onedr0p/manage-this-node/issues/30)